### PR TITLE
Install fix

### DIFF
--- a/mmpm/core.py
+++ b/mmpm/core.py
@@ -649,7 +649,7 @@ def retrieve_modules() -> dict:
                                 desc += contents.string
 
                 modules[categories[index]].append({
-                    utils.TITLE: title,
+                    utils.TITLE: utils.sanitize_name(title),
                     utils.REPOSITORY: repo,
                     utils.AUTHOR: author,
                     utils.DESCRIPTION: desc

--- a/mmpm/mmpm.py
+++ b/mmpm/mmpm.py
@@ -45,7 +45,7 @@ def main(argv):
 
     elif args.remove:
         if args.ext_module_src:
-            core.remove_external_module_source(modules, [utils.sanitize_name(module) for module in args.remove])
+            core.remove_external_module_source([utils.sanitize_name(module) for module in args.remove])
         else:
             core.remove_modules(modules, [utils.sanitize_name(module) for module in args.remove])
 

--- a/mmpm/mmpm.py
+++ b/mmpm/mmpm.py
@@ -38,16 +38,24 @@ def main(argv):
         core.display_modules(core.search_modules(modules, args.search))
 
     elif args.install:
-        core.install_modules(modules, args.install)
+        install_cleaned = []
+        for module in args.install:
+            install_cleaned.append(utils.sanitize_name(module))
+
+        core.install_modules(modules, install_cleaned)
 
     elif args.install_magicmirror:
         core.install_magicmirror(args.GUI)
 
-    elif args.remove and args.ext_module_src:
-        core.remove_external_module_source(args.remove)
+    elif args.remove:
+        remove_cleaned = []
+        for module in args.remove:
+            remove_cleaned.append(utils.sanitize_name(module))
 
-    elif args.remove and not args.ext_module_src:
-        core.remove_modules(modules, args.remove)
+        if args.ext_module_src:
+            core.remove_external_module_source(remove_cleaned)
+        else:
+            core.remove_modules(modules, remove_cleaned)
 
     elif args.list_installed:
         installed_modules = core.get_installed_modules(modules)

--- a/mmpm/mmpm.py
+++ b/mmpm/mmpm.py
@@ -38,24 +38,16 @@ def main(argv):
         core.display_modules(core.search_modules(modules, args.search))
 
     elif args.install:
-        install_cleaned = []
-        for module in args.install:
-            install_cleaned.append(utils.sanitize_name(module))
-
-        core.install_modules(modules, install_cleaned)
+        core.install_modules(modules, [utils.sanitize_name(module) for module in args.install])
 
     elif args.install_magicmirror:
         core.install_magicmirror(args.GUI)
 
     elif args.remove:
-        remove_cleaned = []
-        for module in args.remove:
-            remove_cleaned.append(utils.sanitize_name(module))
-
         if args.ext_module_src:
-            core.remove_external_module_source(remove_cleaned)
+            core.remove_external_module_source(modules, [utils.sanitize_name(module) for module in args.remove])
         else:
-            core.remove_modules(modules, remove_cleaned)
+            core.remove_modules(modules, [utils.sanitize_name(module) for module in args.remove])
 
     elif args.list_installed:
         installed_modules = core.get_installed_modules(modules)

--- a/mmpm/utils.py
+++ b/mmpm/utils.py
@@ -7,6 +7,7 @@ import logging.handlers
 import time
 from os.path import join
 from typing import List, Optional, Tuple
+from re import sub
 from mmpm import colors
 
 # String constants
@@ -200,6 +201,17 @@ def get_file_path(path: str) -> str:
     '''
     return path if os.path.exists(path) else ''
 
+def sanitize_name(orig_name: str) -> str:
+    '''
+    Sanitizes a file- or foldername in that it removes bad characters.
+
+    Parameters:
+        orig_name (str): A file- or foldername with potential bad characters
+
+    Returns:
+        a cleaned version of the file- or foldername
+    '''
+    return sub('[//]', '', orig_name)
 
 def open_default_editor(file_path: str) -> Optional[None]:
     '''


### PR DESCRIPTION
This PR solves a problem (for me) in that it was not possible to install the module MMM-Carousel w/ Navigation".
Previously:
```
mmpm -i MMM-Carousel w/ Navigation
```
installed the MMM-Carousel and
```
mmpm -i "MMM-Carousel w/ Navigation"
```
produced a error in that it could not create the folder because of the /

My solution is to cleanup the module names of the input argument and the parsed webpage and work with the sanitzed names.

BTW, thank you very much for this awesome project, it is really top for handling magic mirror!