### PR TITLE
fix socket cors errors

### DIFF
--- a/gui/package.json
+++ b/gui/package.json
@@ -29,7 +29,7 @@
     "material-icons": "^0.3.1",
     "ngx-monaco-editor": "^8.1.1",
     "rxjs": "~6.5.4",
-    "socket.io-client": "^2.3.0",
+    "socket.io-client": "^3.0.5",
     "tslib": "^1.10.0",
     "wetty": "^1.3.2",
     "xterm-addon-attach": "^0.5.0",

--- a/gui/src/app/components/magic-mirror-control-center/magic-mirror-control-center.component.ts
+++ b/gui/src/app/components/magic-mirror-control-center/magic-mirror-control-center.component.ts
@@ -10,7 +10,7 @@ import { ActiveModule } from "src/app/interfaces/interfaces";
 import { MatSlideToggleChange } from "@angular/material/slide-toggle";
 import { MMPMUtility } from "src/app/utils/mmpm-utility";
 import { SelectModalComponent } from "src/app/components/select-modal/select-modal.component";
-import io from "socket.io-client";
+import { io } from "socket.io-client";
 
 interface Tile {
   icon: string;


### PR DESCRIPTION
The new MagicMirror release v2.14.0 is using sockets.io v3 which has breaking changes concerning cors.
See https://github.com/MichMich/MagicMirror/pull/2411

Problems:
- the next MagicMirror release is 1. April (the above mm pr is only merged to `develop` until then)
- this PR seems not backward compatible, in my tests it worked not for MagicMirror versions before v2.14.0

I have no idea how to solve this so its upon you when this should be merged or may you find a better solution.