### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ The MagicMirror Package Manager is featured as an alternative installation metho
 
 ```sh
 sudo apt install libffi-dev nginx-full -y
+mkdir -p ~/.local/bin
 python3 -m pip install --upgrade --no-cache-dir mmpm
+source ~/.profile
 mmpm --guided-setup
 echo 'export PATH="$PATH:$HOME/.local/bin"' >> ~/.bashrc
 ```


### PR DESCRIPTION
Thanks, very cool project

I added 
```
mkdir -p ~/.local/bin
```
and 
```
source ~/.profile
```

because in my installation the folder `.local/bin` was missing
after installing `mmmpm` I added the command `source ~/.profile` to reload the `.profile` file. So it can reload the `.local/bin/` folder.