### PR TITLE
refactor: simplify script commands in package.json

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -1,16 +1,16 @@
 {
-  "name": "MMPM-UI",
+  "name": "mmpm-ui",
   "version": "0.0.0",
   "scripts": {
-    "ng": "./node_modules/@angular/cli/bin/ng.js",
-    "start": "./node_modules/@angular/cli/bin/ng.js serve",
-    "serve": "./node_modules/@angular/cli/bin/ng.js serve",
-    "serve-prod": "./node_modules/@angular/cli/bin/ng.js serve --configuration production",
-    "build": "./node_modules/@angular/cli/bin/ng.js build",
-    "watch": "./node_modules/@angular/cli/bin/ng.js build --watch --configuration development",
-    "lint": "./node_modules/@angular/cli/bin/ng.js lint",
-    "test": "./node_modules/@angular/cli/bin/ng.js test",
-    "format": "for file in src/app; do ./node_modules/prettier/bin/prettier.cjs --write $file; done"
+    "ng": "ng",
+    "start": "ng serve",
+    "serve": "ng serve",
+    "serve-prod": "ng serve --configuration production",
+    "build": "ng build",
+    "watch": "ng build --watch --configuration development",
+    "lint": "ng lint",
+    "test": "ng test",
+    "format": "prettier --write 'src/app/**/*'"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
The script commands don't have to be so long and the name value has to be lower case.