### PR TITLE
chore: update Node.js version matrix in workflow

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ["18.x", "20.x", "22"]
+        node-version: ["20", "22", "24"]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Version 18 has reached the end of life and version 24 has been released.