### PR TITLE
fix: fix UI API routing, log viewer reliability, and UX polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -442,3 +442,17 @@
 - Fixed test suite after `MMPMEnv` class-level attribute refactor: replaced instance-attribute assignment (blocked by `__slots__`) with `patch.object(MagicMirrorPackage, "env", ...)` + `addCleanup`
 - All 245 tests passing
 
+## Version 4.6.1
+
+### UI
+
+- Fixed 404 errors on `/api/env`, `/api/packages`, and `/api/mmpm/version`: the `mmpm.ui` PM2 process now runs the Flask app (gunicorn) on port 7890 instead of `python -m http.server`, so the Angular SPA is served with `window.MMPM_CONFIG` injection and relative `/api/*` calls resolve correctly
+- Log stream viewer: server-side replay buffer (last 500 entries) so logs accumulated while the panel was navigated away are shown immediately on return
+- Log stream viewer: auto-follow scrolling rewritten using Monaco's `onDidChangeModelContent` event and `setScrollPosition` — eliminates the timing race that caused follow mode to silently drop out after a few entries
+- Log stream viewer: "Follow" button appears in the toolbar when auto-scroll is paused; clicking it jumps to the bottom and re-enables following; scrolling back to the bottom re-enables it automatically
+- Log stream viewer: level filter bar (DEBUG / INFO / WARNING / ERROR / CRITICAL) with per-level color coding; selected levels persisted as a cookie (`mmpm-log-level-filter`)
+- Log stream viewer: configurable auto-clear window (1 h / 2 h / 4 h / **6 h** default / 12 h / 24 h) with selection persisted as a cookie (`mmpm-log-max-age-h`); old entries pruned every 2 minutes in the background
+- Database dropdown (update, upgrades) added to the "Installed" panel header, matching the Marketplace panel
+- Category filter bars in Marketplace and Installed panels are now drag-scrollable with the mouse; cursor changes to a grab hand as a visual affordance
+- PrimeNG toast notifications restyled to match the dark UI: dark `--bg-2` base, per-severity colored borders and summary text (signal / warn / danger / accent-2), bright `--fg-1` detail text; achieved via `definePreset` dark token overrides and `darkModeSelector: ':root'`
+

--- a/mmpm/log/server.py
+++ b/mmpm/log/server.py
@@ -2,6 +2,8 @@
 An incredibly simplistic SocketIO server used for repeating logs from the MMPM CLI to the UI.
 """
 
+from collections import deque
+
 from gevent import monkey
 
 monkey.patch_all()
@@ -15,13 +17,17 @@ logger = MMPMLogFactory.get_logger(__name__)
 
 def create():
     server = socketio.Server(cors_allowed_origins="*", async_mode="gevent")
+    log_buffer: deque = deque(maxlen=500)
 
     @server.event
     def connect(sid, environ):  # pylint: disable=unused-argument
         logger.debug(f"Client connected to SocketIO-Log-Server: {sid}")
+        for entry in log_buffer:
+            server.emit("logs", entry, to=sid)
 
     @server.event
     def logs(sid, data):
+        log_buffer.append(data)
         server.emit("logs", data, skip_sid=sid)
 
     @server.event

--- a/mmpm/ui.py
+++ b/mmpm/ui.py
@@ -1,4 +1,3 @@
-import importlib.resources as pkg_resources
 import json
 import os
 from shutil import rmtree, which
@@ -52,7 +51,7 @@ class MMPMui(Singleton):
                 {
                     "namespace": namespace,
                     "name": f"{namespace}.ui",
-                    "script": f"{python} -m http.server -d {pkg_resources.files('mmpm').resolve() / 'ui'} -b 0.0.0.0 {urls.MMPM_UI_PORT}",
+                    "script": f"{gunicorn} -k gevent -b 0.0.0.0:{urls.MMPM_UI_PORT} mmpm.wsgi:app",
                     "version": version,
                     "watch": True,
                 },

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -19,6 +19,53 @@ import { MirrorPreviewComponent } from "./components/mirror-preview/mirror-previ
 import { CurrentlyInstalledComponent } from "./components/currently-installed/currently-installed.component";
 import { providePrimeNG } from "primeng/config";
 import Aura from "@primeuix/themes/aura";
+import { definePreset } from "@primeuix/themes";
+import { DragScrollDirective } from "./directives/drag-scroll.directive";
+
+// Design tokens matching styles.scss oklch palette
+const MMPMPreset = definePreset(Aura, {
+  components: {
+    toast: {
+      colorScheme: {
+        dark: {
+          root: { blur: '0' },
+          info: {
+            background:   'oklch(0.72 0.07 200 / 0.12)',
+            borderColor:  'oklch(0.72 0.07 200 / 0.35)',
+            color:        'oklch(0.72 0.07 200)',
+            detailColor:  'oklch(0.90 0.006 80)',
+            shadow:       '0 8px 24px oklch(0 0 0 / 0.40)',
+            closeButton:  { hoverBackground: 'oklch(0.72 0.07 200 / 0.12)' },
+          },
+          success: {
+            background:   'oklch(0.78 0.12 160 / 0.12)',
+            borderColor:  'oklch(0.78 0.12 160 / 0.35)',
+            color:        'oklch(0.78 0.12 160)',
+            detailColor:  'oklch(0.90 0.006 80)',
+            shadow:       '0 8px 24px oklch(0 0 0 / 0.40)',
+            closeButton:  { hoverBackground: 'oklch(0.78 0.12 160 / 0.12)' },
+          },
+          warn: {
+            background:   'oklch(0.83 0.11 75 / 0.12)',
+            borderColor:  'oklch(0.83 0.11 75 / 0.35)',
+            color:        'oklch(0.83 0.11 75)',
+            detailColor:  'oklch(0.90 0.006 80)',
+            shadow:       '0 8px 24px oklch(0 0 0 / 0.40)',
+            closeButton:  { hoverBackground: 'oklch(0.83 0.11 75 / 0.12)' },
+          },
+          error: {
+            background:   'oklch(0.68 0.14 22 / 0.12)',
+            borderColor:  'oklch(0.68 0.14 22 / 0.35)',
+            color:        'oklch(0.68 0.14 22)',
+            detailColor:  'oklch(0.90 0.006 80)',
+            shadow:       '0 8px 24px oklch(0 0 0 / 0.40)',
+            closeButton:  { hoverBackground: 'oklch(0.68 0.14 22 / 0.12)' },
+          },
+        },
+      },
+    },
+  },
+});
 
 export function init_shared_store(store: SharedStoreService) {
   return () => store.load();
@@ -27,6 +74,7 @@ export function init_shared_store(store: SharedStoreService) {
 @NgModule({
   declarations: [
     AppComponent,
+    DragScrollDirective,
     MarketPlaceComponent,
     LogStreamViewerComponent,
     ConfigEditorComponent,
@@ -48,9 +96,9 @@ export function init_shared_store(store: SharedStoreService) {
     },
     providePrimeNG({
       theme: {
-        preset: Aura,
+        preset: MMPMPreset,
         options: {
-          darkModeSelector: false,
+          darkModeSelector: ':root',
         },
       },
     }),

--- a/ui/src/app/components/currently-installed/currently-installed.component.html
+++ b/ui/src/app/components/currently-installed/currently-installed.component.html
@@ -8,6 +8,7 @@
     <button [class.active]="viewMode === 'cards'" (click)="viewModeChange.emit('cards')">CARDS</button>
     <button [class.active]="viewMode === 'table'" (click)="viewModeChange.emit('table')">TABLE</button>
   </div>
+  <app-database-info (openPanel)="openPanel.emit($event)"></app-database-info>
 </div>
 
 <div class="toolbar">
@@ -46,7 +47,7 @@
   }
 </div>
 
-<div class="filterbar">
+<div class="filterbar" dragScroll>
   @for (cat of categories; track cat) {
     <button
       class="cat-chip"

--- a/ui/src/app/components/currently-installed/currently-installed.component.scss
+++ b/ui/src/app/components/currently-installed/currently-installed.component.scss
@@ -46,6 +46,8 @@
   overflow-x: auto;
   flex-shrink: 0;
   scrollbar-width: none;
+  cursor: grab;
+
   &::-webkit-scrollbar { display: none; }
 
   .cat-chip {

--- a/ui/src/app/components/log-stream-viewer/log-stream-viewer.component.html
+++ b/ui/src/app/components/log-stream-viewer/log-stream-viewer.component.html
@@ -1,18 +1,47 @@
 <div class="logs-toolbar">
-  <button class="btn" (click)="onDownload()">
-    <i class="fa-solid fa-download"></i> Download
-  </button>
-  <div class="chip">
-    <span class="dot" [style.background]="socket?.connected ? 'var(--signal)' : 'var(--danger)'"></span>
-    {{ socket?.connected ? 'LIVE' : 'DISCONNECTED' }}
+  <div class="toolbar-row">
+    <button class="btn sm" (click)="onDownload()">
+      <i class="fa-solid fa-download"></i> Download
+    </button>
+    <div class="chip">
+      <span class="dot" [style.background]="socket?.connected ? 'var(--signal)' : 'var(--danger)'"></span>
+      {{ socket?.connected ? 'LIVE' : 'DISCONNECTED' }}
+    </div>
+    <div class="spacer"></div>
+    @if (!following) {
+      <button class="btn sm btn-follow" (click)="scrollToBottom()">
+        <i class="fa-solid fa-angles-down"></i> Follow
+      </button>
+    }
+    <div class="font-size-ctrl">
+      <span class="font-label">Size</span>
+      <div class="segmented">
+        <button [class.active]="fontSize === 10" (click)="fontSize = 10; onFontSizeChange()">10</button>
+        <button [class.active]="fontSize === 12" (click)="fontSize = 12; onFontSizeChange()">12</button>
+        <button [class.active]="fontSize === 14" (click)="fontSize = 14; onFontSizeChange()">14</button>
+      </div>
+    </div>
   </div>
-  <div class="spacer"></div>
-  <div class="font-size-ctrl">
-    <span class="font-label">Size</span>
-    <div class="segmented">
-      <button [class.active]="fontSize === 10" (click)="fontSize = 10; onFontSizeChange()">10</button>
-      <button [class.active]="fontSize === 12" (click)="fontSize = 12; onFontSizeChange()">12</button>
-      <button [class.active]="fontSize === 14" (click)="fontSize = 14; onFontSizeChange()">14</button>
+
+  <div class="toolbar-row level-filter-row">
+    <span class="font-label">Levels</span>
+    @for (level of ALL_LEVELS; track level) {
+      <button
+        class="level-btn"
+        [class]="'level-' + level.toLowerCase()"
+        [class.active]="activeLevels.has(level)"
+        (click)="toggleLevel(level)">
+        {{ level }}
+      </button>
+    }
+    <div class="spacer"></div>
+    <div class="font-size-ctrl">
+      <span class="font-label">Clear after</span>
+      <div class="segmented">
+        @for (h of MAX_AGE_OPTIONS; track h) {
+          <button [class.active]="maxAgeHours === h" (click)="setMaxAge(h)">{{ h }}h</button>
+        }
+      </div>
     </div>
   </div>
 </div>

--- a/ui/src/app/components/log-stream-viewer/log-stream-viewer.component.scss
+++ b/ui/src/app/components/log-stream-viewer/log-stream-viewer.component.scss
@@ -6,11 +6,20 @@
 
 .logs-toolbar {
   display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 10px 16px;
+  flex-direction: column;
   border-bottom: 1px solid var(--line-soft);
   flex-shrink: 0;
+}
+
+.toolbar-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 16px;
+
+  &:not(:last-child) {
+    border-bottom: 1px solid var(--line-soft);
+  }
 
   .spacer { flex: 1; }
 
@@ -28,6 +37,62 @@
   }
 }
 
+/* ── Follow button ── */
+.btn-follow {
+  color: var(--accent);
+  border-color: var(--accent);
+  animation: follow-pulse 1.8s ease-in-out infinite;
+}
+
+@keyframes follow-pulse {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.55; }
+}
+
+/* ── Level filter row ── */
+.level-filter-row { }
+
+.level-btn {
+  padding: 3px 8px;
+  border-radius: 4px;
+  border: 1px solid transparent;
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  opacity: 0.35;
+  transition: opacity 120ms, background 120ms, border-color 120ms;
+  cursor: pointer;
+
+  &.active { opacity: 1; }
+
+  &.level-debug {
+    color: var(--fg-3);
+    &.active { background: oklch(0.62 0.011 80 / 0.15); border-color: oklch(0.62 0.011 80 / 0.35); }
+  }
+
+  &.level-info {
+    color: var(--signal);
+    &.active { background: oklch(0.78 0.12 160 / 0.12); border-color: oklch(0.78 0.12 160 / 0.35); }
+  }
+
+  &.level-warning {
+    color: var(--warn);
+    &.active { background: oklch(0.83 0.11 75 / 0.12); border-color: oklch(0.83 0.11 75 / 0.35); }
+  }
+
+  &.level-error {
+    color: var(--danger);
+    &.active { background: oklch(0.68 0.14 22 / 0.12); border-color: oklch(0.68 0.14 22 / 0.35); }
+  }
+
+  &.level-critical {
+    color: oklch(0.72 0.18 15);
+    &.active { background: oklch(0.72 0.18 15 / 0.15); border-color: oklch(0.72 0.18 15 / 0.4); }
+  }
+}
+
+/* ── Editor ── */
 .logs-empty {
   flex: 1;
   animation: tab-enter 220ms ease both;

--- a/ui/src/app/components/log-stream-viewer/log-stream-viewer.component.ts
+++ b/ui/src/app/components/log-stream-viewer/log-stream-viewer.component.ts
@@ -1,6 +1,7 @@
 import {
   Component,
   HostListener,
+  NgZone,
   OnDestroy,
   OnInit,
   ViewChild,
@@ -11,6 +12,19 @@ import { getCookie, setCookie } from '@/utils/utils';
 import { BaseAPI } from '@/services/api/base-api';
 import { EditorComponent } from 'ngx-monaco-editor-v2';
 
+type LogLevel = 'DEBUG' | 'INFO' | 'WARNING' | 'ERROR' | 'CRITICAL';
+
+interface LogEntry {
+  raw: string;
+  level: LogLevel;
+  timestamp: Date;
+}
+
+const ALL_LEVELS: LogLevel[] = ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'];
+const MAX_AGE_OPTIONS = [1, 2, 4, 6, 12, 24] as const;
+const DEFAULT_MAX_AGE_H = 6;
+const PRUNE_INTERVAL_MS = 2 * 60 * 1000; // check every 2 minutes
+
 @Component({
   selector: 'app-log-stream-viewer',
   templateUrl: './log-stream-viewer.component.html',
@@ -19,13 +33,24 @@ import { EditorComponent } from 'ngx-monaco-editor-v2';
 })
 export class LogStreamViewerComponent implements OnInit, OnDestroy {
   private base_api = inject(BaseAPI);
+  private zone = inject(NgZone);
 
   @ViewChild(EditorComponent, { static: false })
   public editor: EditorComponent;
 
   public socket: Socket | undefined;
   public logs = '';
+  public following = true;
   public fontSize = Number(getCookie('mmpm-log-stream-font-size', '12'));
+  public readonly ALL_LEVELS = ALL_LEVELS;
+  public readonly MAX_AGE_OPTIONS = MAX_AGE_OPTIONS;
+  public activeLevels = new Set<LogLevel>(this.loadLevelCookie());
+  public maxAgeHours: number = this.loadMaxAgeCookie();
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private monacoEditor: any = null;
+  private allLogs: LogEntry[] = [];
+  private pruneTimer: ReturnType<typeof setInterval> | null = null;
 
   public options = {
     language: 'text',
@@ -33,9 +58,7 @@ export class LogStreamViewerComponent implements OnInit, OnDestroy {
     theme: 'vs-dark',
     scrollBeyondLastLine: false,
     fontSize: this.fontSize,
-    minimap: {
-      enabled: false,
-    },
+    minimap: { enabled: false },
     scrollbar: {
       useShadows: true,
       verticalHasArrows: false,
@@ -51,31 +74,69 @@ export class LogStreamViewerComponent implements OnInit, OnDestroy {
   public ngOnInit(): void {
     this.fontSize = Number(getCookie('mmpm-log-stream-font-size', '12'));
 
-    this.socket = io(`ws://${window.location.hostname}:6789`, {
-      reconnection: true,
-    });
+    this.socket = io(`ws://${window.location.hostname}:6789`, { reconnection: true });
 
     this.socket.on('connect', () => {
       console.log('Connected to Socket.IO log server');
     });
 
     this.socket.on('connect_error', () => {
-      console.log('Failed to connect to MMPM Log Server ');
+      console.log('Failed to connect to MMPM Log Server');
     });
 
     this.socket.on('logs', (data: string) => {
-      this.logs += data + '\n\n';
+      const entry = this.parseEntry(data);
+      this.allLogs.push(entry);
+      if (this.activeLevels.has(entry.level)) {
+        this.logs += entry.raw + '\n\n';
+        // scrolling is handled by onDidChangeModelContent once Monaco updates
+      }
     });
+
+    this.pruneTimer = setInterval(() => this.pruneOldLogs(), PRUNE_INTERVAL_MS);
   }
 
   public ngOnDestroy(): void {
-    if (this.socket?.connected) {
-      this.socket.disconnect();
-    }
+    if (this.socket?.connected) this.socket.disconnect();
+    if (this.pruneTimer) clearInterval(this.pruneTimer);
   }
 
-  public onEditorInit(editor: EditorComponent): void {
-    this.editor = editor;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public onEditorInit(editor: any): void {
+    this.monacoEditor = editor;
+
+    // Fires after Monaco's model is already updated — safe to read true scrollHeight
+    editor.onDidChangeModelContent(() => {
+      if (this.following) {
+        editor.setScrollPosition({ scrollTop: editor.getScrollHeight() });
+      }
+    });
+
+    editor.onDidScrollChange(() => {
+      const scrollTop: number = editor.getScrollTop();
+      const scrollHeight: number = editor.getScrollHeight();
+      const height: number = editor.getLayoutInfo().height;
+      const atBottom = scrollTop + height >= scrollHeight - 20;
+      this.zone.run(() => { this.following = atBottom; });
+    });
+  }
+
+  public scrollToBottom(): void {
+    if (!this.monacoEditor) return;
+    this.following = true;
+    this.monacoEditor.setScrollPosition({ scrollTop: this.monacoEditor.getScrollHeight() });
+  }
+
+  public toggleLevel(level: LogLevel): void {
+    const next = new Set(this.activeLevels);
+    if (next.has(level)) {
+      next.delete(level);
+    } else {
+      next.add(level);
+    }
+    this.activeLevels = next;
+    setCookie('mmpm-log-level-filter', [...next].join(','));
+    this.recomputeLogs();
   }
 
   public onFontSizeChange(): void {
@@ -83,29 +144,73 @@ export class LogStreamViewerComponent implements OnInit, OnDestroy {
     this.options = Object.assign({}, this.options, { fontSize: this.fontSize });
   }
 
-  public onDownload() {
+  public onDownload(): void {
     this.base_api.getZipArchive('logs/archive').then((archive: ArrayBuffer) => {
       const blob = new Blob([archive], { type: 'application/zip' });
       const date = new Date();
-
       const file_name = `mmpm-logs-${date.getFullYear()}-${date.getMonth()}-${date.getDay()}.zip`;
-      const url: string = URL.createObjectURL(blob);
-      const a: HTMLAnchorElement = document.createElement(
-        'a',
-      ) as HTMLAnchorElement;
-
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a') as HTMLAnchorElement;
       a.href = url;
       a.download = file_name;
       document.body.appendChild(a);
       a.click();
-
       document.body.removeChild(a);
       URL.revokeObjectURL(url);
     });
   }
 
   @HostListener('window:beforeunload')
-  public beforeUnload() {
+  public beforeUnload(): void {
     this.socket?.close();
+  }
+
+  private loadLevelCookie(): LogLevel[] {
+    const saved = getCookie('mmpm-log-level-filter', ALL_LEVELS.join(','));
+    const parsed = saved.split(',').filter((v): v is LogLevel => (ALL_LEVELS as string[]).includes(v));
+    return parsed.length ? parsed : ALL_LEVELS;
+  }
+
+  private parseEntry(raw: string): LogEntry {
+    let level: LogLevel = 'INFO';
+    let timestamp = new Date();
+    try {
+      const parsed = JSON.parse(raw);
+      if (ALL_LEVELS.includes(parsed.level)) level = parsed.level as LogLevel;
+      // Python formatTime: "2024-01-15 10:30:45,123" — fix separators for Date()
+      const tsStr = String(parsed.timestamp ?? '').replace(',', '.').replace(' ', 'T');
+      const d = new Date(tsStr);
+      if (!isNaN(d.getTime())) timestamp = d;
+    } catch { /* non-JSON line; treat as INFO with current time */ }
+    return { raw, level, timestamp };
+  }
+
+  private recomputeLogs(): void {
+    this.logs = this.allLogs
+      .filter(e => this.activeLevels.has(e.level))
+      .map(e => e.raw)
+      .join('\n\n');
+    // onDidChangeModelContent handles scroll if following
+  }
+
+  public setMaxAge(hours: number): void {
+    this.maxAgeHours = hours;
+    setCookie('mmpm-log-max-age-h', String(hours));
+    this.pruneOldLogs();
+  }
+
+  private pruneOldLogs(): void {
+    const cutoff = Date.now() - this.maxAgeHours * 60 * 60 * 1000;
+    const before = this.allLogs.length;
+    this.allLogs = this.allLogs.filter(e => e.timestamp.getTime() >= cutoff);
+    if (this.allLogs.length !== before) {
+      this.zone.run(() => this.recomputeLogs());
+    }
+  }
+
+  private loadMaxAgeCookie(): number {
+    const raw = getCookie('mmpm-log-max-age-h', String(DEFAULT_MAX_AGE_H));
+    const parsed = Number(raw);
+    return (MAX_AGE_OPTIONS as readonly number[]).includes(parsed) ? parsed : DEFAULT_MAX_AGE_H;
   }
 }

--- a/ui/src/app/components/marketplace/marketplace.component.html
+++ b/ui/src/app/components/marketplace/marketplace.component.html
@@ -46,7 +46,7 @@
   </div>
 </div>
 
-<div class="filterbar">
+<div class="filterbar" dragScroll>
   @for (cat of categories; track cat) {
     <button
       class="cat-chip"

--- a/ui/src/app/components/marketplace/marketplace.component.scss
+++ b/ui/src/app/components/marketplace/marketplace.component.scss
@@ -52,6 +52,7 @@
   overflow-x: auto;
   flex-shrink: 0;
   scrollbar-width: none;
+  cursor: grab;
 
   &::-webkit-scrollbar { display: none; }
 

--- a/ui/src/app/directives/drag-scroll.directive.ts
+++ b/ui/src/app/directives/drag-scroll.directive.ts
@@ -1,0 +1,45 @@
+import { Directive, ElementRef, HostListener, inject } from '@angular/core';
+
+@Directive({ selector: '[dragScroll]', standalone: false })
+export class DragScrollDirective {
+  private el = inject(ElementRef<HTMLElement>);
+
+  private dragging = false;
+  private startX = 0;
+  private startScrollLeft = 0;
+  private moved = false;
+
+  @HostListener('mousedown', ['$event'])
+  onMouseDown(e: MouseEvent): void {
+    if (e.button !== 0) return;
+    this.dragging = true;
+    this.moved = false;
+    this.startX = e.clientX;
+    this.startScrollLeft = this.el.nativeElement.scrollLeft;
+    this.el.nativeElement.style.cursor = 'grabbing';
+    this.el.nativeElement.style.userSelect = 'none';
+  }
+
+  @HostListener('document:mousemove', ['$event'])
+  onMouseMove(e: MouseEvent): void {
+    if (!this.dragging) return;
+    const dx = e.clientX - this.startX;
+    if (Math.abs(dx) > 4) this.moved = true;
+    this.el.nativeElement.scrollLeft = this.startScrollLeft - dx;
+  }
+
+  @HostListener('document:mouseup')
+  onMouseUp(): void {
+    this.dragging = false;
+    this.el.nativeElement.style.cursor = '';
+    this.el.nativeElement.style.userSelect = '';
+  }
+
+  @HostListener('click', ['$event'])
+  onClick(e: MouseEvent): void {
+    if (this.moved) {
+      e.stopPropagation();
+      e.preventDefault();
+    }
+  }
+}

--- a/ui/src/styles.scss
+++ b/ui/src/styles.scss
@@ -329,6 +329,25 @@ a:hover { text-decoration: underline; }
 /* ── PrimeNG global overrides ── */
 .p-toast { z-index: 9999 !important; }
 
+.p-toast-message {
+  /* Solid dark base so the colored tint reads correctly over any backdrop */
+  background-color: oklch(0.23 0.014 320) !important;
+  border-radius: var(--radius-sm) !important;
+  font-family: var(--ui) !important;
+
+  .p-toast-summary {
+    font-size: 14px !important;
+    font-weight: 600 !important;
+    letter-spacing: 0.01em !important;
+  }
+
+  .p-toast-detail {
+    font-size: 13px !important;
+    font-weight: 400 !important;
+    color: oklch(0.90 0.006 80) !important;
+  }
+}
+
 .p-dialog {
   background: var(--bg-1) !important;
   border: 1px solid var(--line) !important;


### PR DESCRIPTION
- Fix 404 on /api/* endpoints: switch mmpm.ui PM2 process from python -m http.server to gunicorn so Flask serves the SPA with window.MMPM_CONFIG injection and /api/* routes resolve correctly
- Add 500-entry replay buffer to log server so logs accumulated while the panel was navigated away appear immediately on return
- Rewrite Monaco auto-follow using onDidChangeModelContent + setScrollPosition to eliminate the timing race that caused follow mode to silently drop after a few entries; add Follow button that appears when auto-scroll is paused
- Add per-level filter bar (DEBUG/INFO/WARNING/ERROR/CRITICAL) with color coding; selected levels persisted as mmpm-log-level-filter cookie
- Add configurable auto-clear window (1h/2h/4h/6h default/12h/24h) persisted as mmpm-log-max-age-h cookie; entries pruned every 2 min
- Add Database dropdown to Installed panel header (matches Marketplace)
- Restyle PrimeNG toasts to match dark UI: dark base, per-severity colored borders/summary, bright detail text via definePreset overrides
- Add DragScrollDirective for mouse drag-scrolling category filter bars in Marketplace and Installed panels