### PR TITLE
fix: remove dist cache step that caused stale wheel to be published t…

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -207,15 +207,6 @@ jobs:
           name: mmpm-wheel
           path: ${{ github.workspace }}/dist/*.whl
 
-      - name: Cache MMPM Artifacts
-        uses: actions/cache@v3
-        with:
-          path: |
-            ${{ github.workspace }}/dist
-          key: python-build-${{ hashFiles('**/uv.lock') }}
-          restore-keys: |
-            python-build-${{ hashFiles('**/uv.lock') }}
-
       - name: Publish to PyPi
         if: startsWith(github.ref, 'refs/tags/') && matrix.python-version == '3.13'
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
…o PyPI

The Cache MMPM Artifacts step in create-artifact restored a cached dist/ after the fresh build, overwriting the new wheel with a prior run's artifact whenever uv.lock was unchanged. The publish step then uploaded the stale wheel.