### PR TITLE
feat(ui): select all upgrades, live status feedback, and cart upgrade…

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -223,4 +223,6 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/') && matrix.python-version == '3.13'
         uses: softprops/action-gh-release@v2
         with:
-          files: ${{ github.workspace }}/dist/*
+          files: |
+            ${{ github.workspace }}/dist/*.whl
+            ${{ github.workspace }}/dist/*.tar.gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -481,3 +481,11 @@
 - Added `sync:version` pre-commit hook that reads the version from `pyproject.toml` and keeps `mmpm/__version__.py` and `ui/package.json` in sync automatically on every commit
 - Removed unused `axios` dependency from the UI
 - Replaced `npm run` with `node --run` in the MagicMirror start command and CI lint step (requires Node 22+)
+
+## Version 4.6.4
+
+### UI
+
+- Available Upgrades panel: added a "Select All" row at the top of the upgrade list; clicking it selects all upgradable packages at once; the checkbox shows a tri-state appearance (checked / indeterminate / unchecked) reflecting the current selection
+- Available Upgrades panel: upgrade operations now show immediate visual feedback — each item transitions to an amber spinner ("working"), then to a green check ("done") or red × ("failed") as results arrive; the "Upgrade selected" button displays "Upgrading…" with a spinning icon while the operation runs; items and the Select All row are disabled during execution to prevent accidental changes mid-run
+- Shopping cart: upgradable packages selected from the Installed view are now correctly routed to `postUpgradePackages` rather than `postRemovePackages`; a dedicated "QUEUED · UPGRADE" section appears in the cart above installs and removals

--- a/mmpm/__version__.py
+++ b/mmpm/__version__.py
@@ -1,5 +1,5 @@
 major = 4
 minor = 6
-patch = 3
+patch = 4
 
 version = f"{major}.{minor}.{patch}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mmpm"
-version = "4.6.3"
+version = "4.6.4"
 description = "MMPM, the MagicMirror Package Manager CLI simplifies the installation, removal, and general maintenance of MagicMirror packages"
 
 authors = [

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "MMPM-UI",
-  "version": "4.6.3",
+  "version": "4.6.4",
   "scripts": {
     "ng": "./node_modules/@angular/cli/bin/ng.js",
     "start": "./node_modules/@angular/cli/bin/ng.js serve",

--- a/ui/src/app/components/database-info/database-info.component.html
+++ b/ui/src/app/components/database-info/database-info.component.html
@@ -65,22 +65,53 @@
   <div class="panel-body">
     @if (upgradesAvailable) {
       <div class="upgrade-list">
+        <button class="upgrade-item select-all-row" [disabled]="isRunning" (click)="toggleSelectAll()">
+          <span class="pkg-check" [class.on]="allUpgradesSelected" [class.indeterminate]="someUpgradesSelected && !allUpgradesSelected">
+            @if (allUpgradesSelected) {
+              <i class="fa-solid fa-check" style="font-size: 8px"></i>
+            } @else if (someUpgradesSelected) {
+              <i class="fa-solid fa-minus" style="font-size: 8px"></i>
+            }
+          </span>
+          <span class="upgrade-title">Select All</span>
+        </button>
         @for (pkg of upgradableItems; track pkg.title) {
-          <button class="upgrade-item" [class.selected]="isUpgradeSelected(pkg)" (click)="toggleUpgrade(pkg)">
-            <span class="pkg-check" [class.on]="isUpgradeSelected(pkg)">
-              @if (isUpgradeSelected(pkg)) {
-                <i class="fa-solid fa-check" style="font-size: 8px"></i>
-              }
-            </span>
+          @let status = opStatus.get(pkg.title);
+          <button class="upgrade-item"
+            [class.selected]="isUpgradeSelected(pkg)"
+            [class.op-working]="status === 'working'"
+            [class.op-done]="status === 'done'"
+            [class.op-failed]="status === 'failed'"
+            [disabled]="isRunning"
+            (click)="toggleUpgrade(pkg)">
+            @if (status === 'working') {
+              <i class="fa-solid fa-spinner fa-spin op-icon"></i>
+            } @else if (status === 'done') {
+              <i class="fa-solid fa-check op-icon op-icon-done"></i>
+            } @else if (status === 'failed') {
+              <i class="fa-solid fa-xmark op-icon op-icon-fail"></i>
+            } @else {
+              <span class="pkg-check" [class.on]="isUpgradeSelected(pkg)">
+                @if (isUpgradeSelected(pkg)) {
+                  <i class="fa-solid fa-check" style="font-size: 8px"></i>
+                }
+              </span>
+            }
             <span class="upgrade-title">{{ pkg.title }}</span>
-            <span class="badge update">UPDATE</span>
+            @if (!status) {
+              <span class="badge update">UPDATE</span>
+            }
           </button>
         }
       </div>
       <div class="panel-actions">
-        <button class="btn ghost" (click)="panelClosed.emit()">Cancel</button>
-        <button class="btn primary" [disabled]="!selectedUpgrades.length" (click)="onUpgrade()">
-          <i class="fa-solid fa-check"></i> Upgrade selected
+        <button class="btn ghost" [disabled]="isRunning" (click)="panelClosed.emit()">Cancel</button>
+        <button class="btn primary" [disabled]="!selectedUpgrades.length || isRunning" (click)="onUpgrade()">
+          @if (isRunning) {
+            <i class="fa-solid fa-spinner fa-spin"></i> Upgrading…
+          } @else {
+            <i class="fa-solid fa-check"></i> Upgrade selected
+          }
         </button>
       </div>
     } @else {

--- a/ui/src/app/components/database-info/database-info.component.scss
+++ b/ui/src/app/components/database-info/database-info.component.scss
@@ -54,6 +54,15 @@
   overflow: hidden;
 }
 
+.select-all-row {
+  background: var(--bg-1) !important;
+  border-bottom: 1px solid var(--line) !important;
+  font-size: 13px !important;
+  color: var(--fg-3) !important;
+
+  &:hover { background: var(--bg-2) !important; color: var(--fg-1) !important; }
+}
+
 .upgrade-item {
   display: flex;
   align-items: center;
@@ -70,14 +79,38 @@
   transition: background 100ms;
 
   &:last-child { border-bottom: none; }
-  &:hover { background: var(--bg-2); }
+  &:hover:not(:disabled) { background: var(--bg-2); }
+  &:disabled { cursor: default; }
   &.selected { background: oklch(0.87 0.07 75 / 0.06); }
+
+  &.op-working {
+    border-bottom-color: oklch(0.87 0.07 75 / 0.3);
+    background: oklch(0.87 0.07 75 / 0.06);
+  }
+  &.op-done {
+    border-bottom-color: oklch(0.78 0.12 160 / 0.3);
+    background: oklch(0.78 0.12 160 / 0.06);
+  }
+  &.op-failed {
+    border-bottom-color: oklch(0.68 0.14 22 / 0.3);
+    background: oklch(0.68 0.14 22 / 0.06);
+  }
 
   .upgrade-title {
     flex: 1;
     font-weight: 500;
   }
 }
+
+.op-icon {
+  font-size: 15px;
+  width: 18px;
+  text-align: center;
+  flex-shrink: 0;
+  color: var(--accent);
+}
+.op-icon-done { color: var(--signal); }
+.op-icon-fail { color: var(--danger); }
 
 .db-btn-wrap {
   position: relative;

--- a/ui/src/app/components/database-info/database-info.component.spec.ts
+++ b/ui/src/app/components/database-info/database-info.component.spec.ts
@@ -1,5 +1,5 @@
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { BehaviorSubject } from 'rxjs';
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { BaseAPI } from '@/services/api/base-api';
@@ -11,6 +11,22 @@ import { DatabaseInfo } from '@/models/database-info';
 import { UpgradableDetails } from '@/models/upgradable-details';
 import { MMPMEnv } from '@/models/mmpm-env';
 import { DatabaseInfoComponent } from './database-info.component';
+
+function makePkg(title: string): MagicMirrorPackage {
+  return {
+    title,
+    author: 'Author',
+    repository: `https://github.com/test/${title}`,
+    description: 'A test module',
+    directory: `/modules/${title}`,
+    category: 'Test',
+    is_installed: true,
+    is_upgradable: true,
+    remote_details: { issues: 0, created: '', forks: 0 },
+    stars: 5,
+    last_updated: '2024-01-01',
+  };
+}
 
 class MockSharedStoreService {
   dbInfo    = new BehaviorSubject<DatabaseInfo>({});
@@ -24,28 +40,44 @@ class MockSharedStoreService {
     MMPM_MAGICMIRROR_ROOT: '',
     MMPM_MAGICMIRROR_URI: '',
   });
+  load = jasmine.createSpy('load');
 }
 
 describe('DatabaseInfoComponent', () => {
   let component: DatabaseInfoComponent;
   let fixture: ComponentFixture<DatabaseInfoComponent>;
+  let mockBaseAPI: jasmine.SpyObj<BaseAPI>;
+  let mockMmPkgApi: jasmine.SpyObj<MagicMirrorPackageAPI>;
+  let mockMmApi: jasmine.SpyObj<MagicMirrorAPI>;
+  let mockStore: MockSharedStoreService;
 
   beforeEach(() => {
-    const mockBaseAPI = jasmine.createSpyObj('BaseAPI', ['get_', 'route', 'headers']);
+    mockBaseAPI = jasmine.createSpyObj('BaseAPI', ['get_', 'route', 'headers']);
     mockBaseAPI.get_.and.returnValue(Promise.resolve({ code: 200, message: '' }));
+
+    mockMmPkgApi = jasmine.createSpyObj('MagicMirrorPackageAPI', ['get_', 'getPackages', 'postUpgradePackages']);
+    mockMmPkgApi.postUpgradePackages.and.returnValue(
+      Promise.resolve({ code: 200, message: { success: [], failure: [] } })
+    );
+
+    mockMmApi = jasmine.createSpyObj('MagicMirrorAPI', ['getStatus', 'getUpgrade']);
+    mockMmApi.getUpgrade.and.returnValue(Promise.resolve({ code: 200, message: '' }));
+
+    mockStore = new MockSharedStoreService();
 
     TestBed.configureTestingModule({
       declarations: [DatabaseInfoComponent],
       providers: [
-        { provide: BaseAPI,              useValue: mockBaseAPI },
-        { provide: MagicMirrorPackageAPI, useValue: jasmine.createSpyObj('MagicMirrorPackageAPI', ['get_', 'getPackages']) },
-        { provide: MagicMirrorAPI,       useValue: jasmine.createSpyObj('MagicMirrorAPI', ['getStatus']) },
-        { provide: SharedStoreService,   useClass: MockSharedStoreService },
-        { provide: MessageService,       useValue: jasmine.createSpyObj('MessageService', ['add']) },
-        { provide: ConfirmationService,  useValue: jasmine.createSpyObj('ConfirmationService', ['confirm']) },
+        { provide: BaseAPI,               useValue: mockBaseAPI },
+        { provide: MagicMirrorPackageAPI, useValue: mockMmPkgApi },
+        { provide: MagicMirrorAPI,        useValue: mockMmApi },
+        { provide: SharedStoreService,    useValue: mockStore },
+        { provide: MessageService,        useValue: jasmine.createSpyObj('MessageService', ['add']) },
+        { provide: ConfirmationService,   useValue: jasmine.createSpyObj('ConfirmationService', ['confirm']) },
       ],
       schemas: [NO_ERRORS_SCHEMA],
     });
+
     fixture = TestBed.createComponent(DatabaseInfoComponent);
     component = fixture.componentInstance;
     component.loading = false;
@@ -54,5 +86,320 @@ describe('DatabaseInfoComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  // ── upgradable store subscription ─────────────────────────────────────────
+
+  describe('upgradable store subscription', () => {
+    it('populates upgradableItems from packages', () => {
+      const pkg = makePkg('MMM-Test');
+      mockStore.upgradable.next({ mmpm: false, MagicMirror: false, packages: [pkg] });
+      expect(component.upgradableItems).toContain(pkg);
+    });
+
+    it('appends MMPM dummy entry when mmpm=true', () => {
+      mockStore.upgradable.next({ mmpm: true, MagicMirror: false, packages: [] });
+      expect(component.upgradableItems.some(p => p.title === 'MMPM')).toBeTrue();
+    });
+
+    it('appends MagicMirror dummy entry when MagicMirror=true', () => {
+      mockStore.upgradable.next({ mmpm: false, MagicMirror: true, packages: [] });
+      expect(component.upgradableItems.some(p => p.title === 'MagicMirror')).toBeTrue();
+    });
+
+    it('sets upgradesAvailable when packages are present', () => {
+      mockStore.upgradable.next({ mmpm: false, MagicMirror: false, packages: [makePkg('A')] });
+      expect(component.upgradesAvailable).toBeTrue();
+    });
+
+    it('sets upgradesAvailable when mmpm=true', () => {
+      mockStore.upgradable.next({ mmpm: true, MagicMirror: false, packages: [] });
+      expect(component.upgradesAvailable).toBeTrue();
+    });
+
+    it('clears upgradesAvailable when nothing to upgrade', () => {
+      mockStore.upgradable.next({ mmpm: false, MagicMirror: false, packages: [] });
+      expect(component.upgradesAvailable).toBeFalse();
+    });
+  });
+
+  // ── isUpgradeSelected / toggleUpgrade ────────────────────────────────────
+
+  describe('isUpgradeSelected', () => {
+    it('returns false when package is not in selectedUpgrades', () => {
+      component.selectedUpgrades = [];
+      expect(component.isUpgradeSelected(makePkg('A'))).toBeFalse();
+    });
+
+    it('returns true when package is in selectedUpgrades', () => {
+      const pkg = makePkg('A');
+      component.selectedUpgrades = [pkg];
+      expect(component.isUpgradeSelected(pkg)).toBeTrue();
+    });
+
+    it('matches by title', () => {
+      component.selectedUpgrades = [makePkg('A')];
+      expect(component.isUpgradeSelected(makePkg('B'))).toBeFalse();
+    });
+  });
+
+  describe('toggleUpgrade', () => {
+    it('adds package to selectedUpgrades when not already selected', () => {
+      const pkg = makePkg('A');
+      component.selectedUpgrades = [];
+      component.toggleUpgrade(pkg);
+      expect(component.selectedUpgrades).toContain(pkg);
+    });
+
+    it('removes package from selectedUpgrades when already selected', () => {
+      const pkg = makePkg('A');
+      component.selectedUpgrades = [pkg];
+      component.toggleUpgrade(pkg);
+      expect(component.selectedUpgrades).not.toContain(pkg);
+    });
+
+    it('preserves other selections when removing one', () => {
+      const pkgA = makePkg('A');
+      const pkgB = makePkg('B');
+      component.selectedUpgrades = [pkgA, pkgB];
+      component.toggleUpgrade(pkgA);
+      expect(component.selectedUpgrades).toContain(pkgB);
+    });
+  });
+
+  // ── Select All ────────────────────────────────────────────────────────────
+
+  describe('allUpgradesSelected', () => {
+    it('returns false when upgradableItems is empty', () => {
+      component.upgradableItems = [];
+      component.selectedUpgrades = [];
+      expect(component.allUpgradesSelected).toBeFalse();
+    });
+
+    it('returns false when no items are selected', () => {
+      component.upgradableItems = [makePkg('A'), makePkg('B')];
+      component.selectedUpgrades = [];
+      expect(component.allUpgradesSelected).toBeFalse();
+    });
+
+    it('returns false when only some items are selected', () => {
+      const pkgA = makePkg('A');
+      const pkgB = makePkg('B');
+      component.upgradableItems = [pkgA, pkgB];
+      component.selectedUpgrades = [pkgA];
+      expect(component.allUpgradesSelected).toBeFalse();
+    });
+
+    it('returns true when every item is selected', () => {
+      const pkgA = makePkg('A');
+      const pkgB = makePkg('B');
+      component.upgradableItems = [pkgA, pkgB];
+      component.selectedUpgrades = [pkgA, pkgB];
+      expect(component.allUpgradesSelected).toBeTrue();
+    });
+  });
+
+  describe('someUpgradesSelected', () => {
+    it('returns false when no items are selected', () => {
+      component.upgradableItems = [makePkg('A'), makePkg('B')];
+      component.selectedUpgrades = [];
+      expect(component.someUpgradesSelected).toBeFalse();
+    });
+
+    it('returns true when a subset of items is selected', () => {
+      const pkgA = makePkg('A');
+      const pkgB = makePkg('B');
+      component.upgradableItems = [pkgA, pkgB];
+      component.selectedUpgrades = [pkgA];
+      expect(component.someUpgradesSelected).toBeTrue();
+    });
+
+    it('returns true when all items are selected', () => {
+      const pkg = makePkg('A');
+      component.upgradableItems = [pkg];
+      component.selectedUpgrades = [pkg];
+      expect(component.someUpgradesSelected).toBeTrue();
+    });
+  });
+
+  describe('toggleSelectAll', () => {
+    it('selects all items when none are selected', () => {
+      const pkgA = makePkg('A');
+      const pkgB = makePkg('B');
+      component.upgradableItems = [pkgA, pkgB];
+      component.selectedUpgrades = [];
+      component.toggleSelectAll();
+      expect(component.selectedUpgrades.length).toBe(2);
+      expect(component.selectedUpgrades).toContain(pkgA);
+      expect(component.selectedUpgrades).toContain(pkgB);
+    });
+
+    it('selects all items when only some are selected', () => {
+      const pkgA = makePkg('A');
+      const pkgB = makePkg('B');
+      component.upgradableItems = [pkgA, pkgB];
+      component.selectedUpgrades = [pkgA];
+      component.toggleSelectAll();
+      expect(component.selectedUpgrades.length).toBe(2);
+    });
+
+    it('deselects all items when all are already selected', () => {
+      const pkgA = makePkg('A');
+      const pkgB = makePkg('B');
+      component.upgradableItems = [pkgA, pkgB];
+      component.selectedUpgrades = [pkgA, pkgB];
+      component.toggleSelectAll();
+      expect(component.selectedUpgrades.length).toBe(0);
+    });
+
+    it('does nothing to selection when upgradableItems is empty', () => {
+      component.upgradableItems = [];
+      component.selectedUpgrades = [];
+      component.toggleSelectAll();
+      expect(component.selectedUpgrades.length).toBe(0);
+    });
+  });
+
+  // ── upgrade() – immediate visual feedback ─────────────────────────────────
+
+  describe('upgrade() status tracking', () => {
+    let pkgA: MagicMirrorPackage;
+    let pkgB: MagicMirrorPackage;
+
+    beforeEach(() => {
+      pkgA = makePkg('MMM-Alpha');
+      pkgB = makePkg('MMM-Beta');
+      component.upgradableItems = [pkgA, pkgB];
+      component.selectedUpgrades = [pkgA, pkgB];
+    });
+
+    it('sets isRunning to true immediately when upgrade starts', fakeAsync(() => {
+      component.upgrade();
+      expect(component.isRunning).toBeTrue();
+      tick(1400);
+    }));
+
+    it('sets all selected packages to working in opStatus immediately', fakeAsync(() => {
+      component.upgrade();
+      expect(component.opStatus.get('MMM-Alpha')).toBe('working');
+      expect(component.opStatus.get('MMM-Beta')).toBe('working');
+      tick(1400);
+    }));
+
+    it('marks packages as done when API reports success', fakeAsync(() => {
+      mockMmPkgApi.postUpgradePackages.and.returnValue(Promise.resolve({
+        code: 200,
+        message: { success: [pkgA, pkgB], failure: [] },
+      }));
+      component.upgrade();
+      tick(0);
+      expect(component.opStatus.get('MMM-Alpha')).toBe('done');
+      expect(component.opStatus.get('MMM-Beta')).toBe('done');
+      tick(1400);
+    }));
+
+    it('marks packages as failed when API reports failure', fakeAsync(() => {
+      mockMmPkgApi.postUpgradePackages.and.returnValue(Promise.resolve({
+        code: 200,
+        message: {
+          success: [],
+          failure: [
+            { title: 'MMM-Alpha', error: 'git error' },
+            { title: 'MMM-Beta',  error: 'git error' },
+          ],
+        },
+      }));
+      component.upgrade();
+      tick(0);
+      expect(component.opStatus.get('MMM-Alpha')).toBe('failed');
+      expect(component.opStatus.get('MMM-Beta')).toBe('failed');
+      tick(1400);
+    }));
+
+    it('marks individual packages done or failed per API response', fakeAsync(() => {
+      mockMmPkgApi.postUpgradePackages.and.returnValue(Promise.resolve({
+        code: 200,
+        message: {
+          success: [pkgA],
+          failure: [{ title: 'MMM-Beta', error: 'git error' }],
+        },
+      }));
+      component.upgrade();
+      tick(0);
+      expect(component.opStatus.get('MMM-Alpha')).toBe('done');
+      expect(component.opStatus.get('MMM-Beta')).toBe('failed');
+      tick(1400);
+    }));
+
+    it('resets isRunning to false after the post-upgrade delay', fakeAsync(() => {
+      component.upgrade();
+      tick(1400);
+      expect(component.isRunning).toBeFalse();
+    }));
+
+    it('clears opStatus after the post-upgrade delay', fakeAsync(() => {
+      component.upgrade();
+      tick(1400);
+      expect(component.opStatus.size).toBe(0);
+    }));
+
+    it('clears selectedUpgrades during the upgrade', fakeAsync(() => {
+      component.upgrade();
+      tick(0);
+      expect(component.selectedUpgrades).toEqual([]);
+      tick(1400);
+    }));
+
+    it('calls postUpgradePackages excluding MMPM and MagicMirror entries', fakeAsync(() => {
+      component.upgrade();
+      tick(1400);
+      expect(mockMmPkgApi.postUpgradePackages).toHaveBeenCalledWith([pkgA, pkgB]);
+    }));
+
+    it('calls store.load() after upgrades complete', fakeAsync(() => {
+      component.upgrade();
+      tick(0);
+      expect(mockStore.load).toHaveBeenCalled();
+      tick(1400);
+    }));
+  });
+
+  // ── upgrade() – MagicMirror status tracking ───────────────────────────────
+
+  describe('upgrade() MagicMirror status', () => {
+    const mmDummy = { ...makePkg('MagicMirror'), title: 'MagicMirror' };
+
+    beforeEach(() => {
+      component.upgradableItems = [mmDummy];
+      component.selectedUpgrades = [mmDummy];
+    });
+
+    it('sets MagicMirror to working immediately', fakeAsync(() => {
+      component.upgrade();
+      expect(component.opStatus.get('MagicMirror')).toBe('working');
+      tick(1400);
+    }));
+
+    it('marks MagicMirror as done when getUpgrade succeeds', fakeAsync(() => {
+      mockMmApi.getUpgrade.and.returnValue(Promise.resolve({ code: 200, message: '' }));
+      component.upgrade();
+      tick(0);
+      expect(component.opStatus.get('MagicMirror')).toBe('done');
+      tick(1400);
+    }));
+
+    it('marks MagicMirror as failed when getUpgrade returns non-200', fakeAsync(() => {
+      mockMmApi.getUpgrade.and.returnValue(Promise.resolve({ code: 500, message: 'error' }));
+      component.upgrade();
+      tick(0);
+      expect(component.opStatus.get('MagicMirror')).toBe('failed');
+      tick(1400);
+    }));
+
+    it('does not call postUpgradePackages when only MagicMirror is selected', fakeAsync(() => {
+      component.upgrade();
+      tick(1400);
+      expect(mockMmPkgApi.postUpgradePackages).not.toHaveBeenCalled();
+    }));
   });
 });

--- a/ui/src/app/components/database-info/database-info.component.ts
+++ b/ui/src/app/components/database-info/database-info.component.ts
@@ -51,6 +51,8 @@ export class DatabaseInfoComponent implements OnInit, OnDestroy {
   public upgradableItems = new Array<MagicMirrorPackage>();
   public selectedPackages = new Array<MagicMirrorPackage>();
   public selectedUpgrades = new Array<MagicMirrorPackage>();
+  public opStatus: Map<string, 'working' | 'done' | 'failed'> = new Map();
+  public isRunning = false;
   private updateDoneTimer: ReturnType<typeof setTimeout> | null = null;
 
 
@@ -132,6 +134,18 @@ export class DatabaseInfoComponent implements OnInit, OnDestroy {
     return this.selectedUpgrades.some(p => p.title === pkg.title);
   }
 
+  public get allUpgradesSelected(): boolean {
+    return this.upgradableItems.length > 0 && this.upgradableItems.every(p => this.isUpgradeSelected(p));
+  }
+
+  public get someUpgradesSelected(): boolean {
+    return this.upgradableItems.some(p => this.isUpgradeSelected(p));
+  }
+
+  public toggleSelectAll(): void {
+    this.selectedUpgrades = this.allUpgradesSelected ? [] : [...this.upgradableItems];
+  }
+
   public toggleUpgrade(pkg: MagicMirrorPackage): void {
     this.selectedUpgrades = this.isUpgradeSelected(pkg)
       ? this.selectedUpgrades.filter(p => p.title !== pkg.title)
@@ -163,54 +177,29 @@ export class DatabaseInfoComponent implements OnInit, OnDestroy {
   }
 
   async upgrade() {
-    const packages = this.selectedUpgrades.filter(
-      (pkg: MagicMirrorPackage) =>
-        pkg.title !== 'MMPM' && pkg.title !== 'MagicMirror',
-    );
+    const toUpgrade = [...this.selectedUpgrades];
+    const packages = toUpgrade.filter(p => p.title !== 'MMPM' && p.title !== 'MagicMirror');
+
+    this.isRunning = true;
+    this.opStatus = new Map(toUpgrade.map(p => [p.title, 'working']));
     this.loadingChange.emit(true);
 
-    if (
-      this.selectedUpgrades.findIndex(
-        (pkg: MagicMirrorPackage) => pkg.title === 'MMPM',
-      ) !== -1
-    ) {
+    if (toUpgrade.find(p => p.title === 'MMPM')) {
+      // fire-and-forget: MMPM restarts itself mid-upgrade
       this.baseApi.get_('mmpm/upgrade').then((response: APIResponse) => {
-        if (response.code === 200) {
-          this.msg.add({
-            severity: 'success',
-            summary: 'Upgrade',
-            detail: 'MMPM has been upgraded',
-          });
-        } else {
-          this.msg.add({
-            severity: 'error',
-            summary: 'Upgrade',
-            detail: response.message,
-          });
-        }
+        this.setOpStatus('MMPM', response.code === 200 ? 'done' : 'failed');
+        this.msg.add(response.code === 200
+          ? { severity: 'success', summary: 'Upgrade', detail: 'MMPM has been upgraded' }
+          : { severity: 'error', summary: 'Upgrade', detail: response.message });
       });
     }
 
-    if (
-      this.selectedUpgrades.findIndex(
-        (pkg: MagicMirrorPackage) => pkg.title === 'MagicMirror',
-      ) !== -1
-    ) {
+    if (toUpgrade.find(p => p.title === 'MagicMirror')) {
       const response = await this.mmApi.getUpgrade();
-
-      if (response.code === 200) {
-        this.msg.add({
-          severity: 'success',
-          summary: 'Upgrade',
-          detail: 'MagicMirror has been upgraded',
-        });
-      } else {
-        this.msg.add({
-          severity: 'error',
-          summary: 'Upgrade',
-          detail: response.message,
-        });
-      }
+      this.setOpStatus('MagicMirror', response.code === 200 ? 'done' : 'failed');
+      this.msg.add(response.code === 200
+        ? { severity: 'success', summary: 'Upgrade', detail: 'MagicMirror has been upgraded' }
+        : { severity: 'error', summary: 'Upgrade', detail: response.message });
     }
 
     this.selectedUpgrades = [];
@@ -220,6 +209,9 @@ export class DatabaseInfoComponent implements OnInit, OnDestroy {
       const succeeded: MagicMirrorPackage[] = response.message?.success ?? [];
       const failures: { title: string; error: string }[] = response.message?.failure ?? [];
 
+      succeeded.forEach(p => this.setOpStatus(p.title, 'done'));
+      failures.forEach(f => this.setOpStatus(f.title, 'failed'));
+
       if (response.code === 200 && succeeded.length > 0) {
         this.msg.add({
           severity: 'success',
@@ -227,37 +219,30 @@ export class DatabaseInfoComponent implements OnInit, OnDestroy {
           detail: `${succeeded.length} package${succeeded.length === 1 ? '' : 's'} upgraded successfully`,
         });
       }
-
       for (const f of failures) {
-        this.msg.add({
-          severity: 'error',
-          summary: `Failed to upgrade ${f.title}`,
-          detail: f.error,
-          life: 8000,
-        });
+        this.msg.add({ severity: 'error', summary: `Failed to upgrade ${f.title}`, detail: f.error, life: 8000 });
       }
     }
 
     // the update endpoint will write out which packages have updates, and this needs
     // to get updated again following the actual upgrades
-    const response = await this.baseApi.get_('db/update');
-
-    if (response.code === 200) {
-      this.msg.add({
-        severity: 'success',
-        summary: 'Upgrade',
-        detail: 'Database updated to reflect changes',
-      });
+    const dbResponse = await this.baseApi.get_('db/update');
+    if (dbResponse.code === 200) {
+      this.msg.add({ severity: 'success', summary: 'Upgrade', detail: 'Database updated to reflect changes' });
     } else {
-      this.msg.add({
-        severity: 'error',
-        summary: 'Upgrade',
-        detail: response.message,
-      });
+      this.msg.add({ severity: 'error', summary: 'Upgrade', detail: dbResponse.message });
     }
 
     this.store.load();
+
+    await new Promise<void>(resolve => setTimeout(resolve, 1400));
+    this.opStatus = new Map();
+    this.isRunning = false;
     this.loadingChange.emit(false);
+  }
+
+  private setOpStatus(title: string, status: 'working' | 'done' | 'failed'): void {
+    this.opStatus = new Map(this.opStatus).set(title, status);
   }
 
   private dummyPackage(title: string): MagicMirrorPackage {

--- a/ui/src/app/components/shopping-cart/shopping-cart.component.html
+++ b/ui/src/app/components/shopping-cart/shopping-cart.component.html
@@ -14,7 +14,30 @@
 
   } @else {
 
-    <div class="section-title">QUEUED · INSTALL</div>
+    <div class="section-title">QUEUED · UPGRADE</div>
+    @for (pkg of upgrades; track pkg.repository) {
+      @let status = opStatus.get(pkgKey(pkg));
+      <div class="cart-item" [class.op-working]="status === 'working'" [class.op-done]="status === 'done'" [class.op-failed]="status === 'failed'">
+        <div class="cart-item-info">
+          <div class="cart-item-name">{{ pkg.title }}</div>
+          <div class="cart-item-author">{{ pkg.author }}</div>
+        </div>
+        @if (status === 'working') {
+          <i class="fa-solid fa-spinner fa-spin op-icon"></i>
+        } @else if (status === 'done') {
+          <i class="fa-solid fa-check op-icon op-icon-done"></i>
+        } @else if (status === 'failed') {
+          <i class="fa-solid fa-xmark op-icon op-icon-fail"></i>
+        } @else {
+          <span class="badge update">UPGRADE</span>
+        }
+      </div>
+    }
+    @if (upgrades.length === 0) {
+      <div class="cart-empty">— none —</div>
+    }
+
+    <div class="section-title" style="margin-top: 12px">QUEUED · INSTALL</div>
     @for (pkg of installs; track pkg.repository) {
       @let status = opStatus.get(pkgKey(pkg));
       <div class="cart-item" [class.op-working]="status === 'working'" [class.op-done]="status === 'done'" [class.op-failed]="status === 'failed'">

--- a/ui/src/app/components/shopping-cart/shopping-cart.component.ts
+++ b/ui/src/app/components/shopping-cart/shopping-cart.component.ts
@@ -38,8 +38,12 @@ export class ShoppingCartComponent {
     return this.selectedPackages.filter(p => !p.is_installed);
   }
 
+  public get upgrades(): MagicMirrorPackage[] {
+    return this.selectedPackages.filter(p => p.is_installed && p.is_upgradable);
+  }
+
   public get removals(): MagicMirrorPackage[] {
-    return this.selectedPackages.filter(p => p.is_installed);
+    return this.selectedPackages.filter(p => p.is_installed && !p.is_upgradable);
   }
 
   public pkgKey(pkg: MagicMirrorPackage): string {
@@ -63,12 +67,24 @@ export class ShoppingCartComponent {
   async checkout() {
     if (!this.selectedPackages?.length) return;
 
-    const toRemove = this.selectedPackages.filter(p => p.is_installed);
-    const toInstall = this.selectedPackages.filter(p => !p.is_installed);
+    const toUpgrade = this.upgrades;
+    const toRemove = this.removals;
+    const toInstall = this.installs;
 
     this.isRunning = true;
     this.opStatus = new Map(this.selectedPackages.map(p => [this.pkgKey(p), 'pending' as OpStatus]));
     this.loadingChange.emit(true);
+
+    for (const pkg of toUpgrade) {
+      this.setStatus(pkg, 'working');
+      const response = await this.mmPkgApi.postUpgradePackages([pkg]);
+      const failure = response.message?.failure?.[0];
+      const success = !failure && response.code === 200;
+      this.setStatus(pkg, success ? 'done' : 'failed');
+      if (!success) {
+        this.msg.add({ severity: 'error', summary: 'Upgrade', detail: `Failed to upgrade ${pkg.title}. See logs for details.` });
+      }
+    }
 
     for (const pkg of toRemove) {
       this.setStatus(pkg, 'working');

--- a/ui/src/styles.scss
+++ b/ui/src/styles.scss
@@ -239,6 +239,12 @@ a:hover { text-decoration: underline; }
     background: var(--accent);
     border-color: var(--accent);
   }
+
+  &.indeterminate {
+    background: oklch(0.83 0.11 75 / 0.2);
+    border-color: var(--warn);
+    color: var(--warn);
+  }
 }
 
 /* ── Section title ── */

--- a/uv.lock
+++ b/uv.lock
@@ -793,7 +793,7 @@ wheels = [
 
 [[package]]
 name = "mmpm"
-version = "4.6.3"
+version = "4.6.4"
 source = { editable = "." }
 dependencies = [
     { name = "argcomplete" },


### PR DESCRIPTION
… routing

- Available Upgrades panel: "Select All" tri-state checkbox row selects/deselects all upgradable packages at once
- Available Upgrades panel: per-item working/done/failed status icons and row tints give immediate visual feedback during the upgrade operation; button shows "Upgrading…" spinner and interactions are disabled while running
- Shopping cart: upgradable installed packages now correctly call postUpgradePackages via a dedicated "QUEUED · UPGRADE" section, separate from removals
- Tests: database-info spec expanded to cover Select All logic, tri-state getters, and the full opStatus/isRunning lifecycle of upgrade()
- Changelog: add 4.6.4 entry