### PR TITLE
feat(env): add MMPM_UI_BASE_URL for reverse-proxy sub-path deployments

### DIFF
--- a/mmpm/api/endpoints/ep_ui.py
+++ b/mmpm/api/endpoints/ep_ui.py
@@ -1,11 +1,11 @@
 import importlib.resources as pkg_resources
 import os
+import re
 from urllib.parse import urlparse
 
-from flask import Blueprint, Response, request, send_from_directory
+from flask import Blueprint, Response, send_from_directory
 
 from mmpm.api.endpoints.endpoint import Endpoint
-from mmpm.constants import urls
 from mmpm.env import MMPMEnv
 from mmpm.log.factory import MMPMLogFactory
 
@@ -16,11 +16,10 @@ _ui_path = str(pkg_resources.files("mmpm").joinpath("ui"))
 
 class Ui(Endpoint):
     """
-    Catch-all endpoint that serves the Angular SPA and injects runtime config
-    (window.MMPM_CONFIG) into index.html so the pre-built bundle works behind
-    a reverse proxy without rebuilding. Configure MMPM_UI_API_BASE_URL,
-    MMPM_UI_SOCKET_URL, and MMPM_UI_BASE_URL in the MMPM env file
-    (~/.config/mmpm/mmpm-env.json).
+    Catch-all endpoint that serves the Angular SPA. Rewrites <base href> in
+    index.html when MMPM_UI_BASE_URL is set so assets and routing resolve
+    correctly behind a reverse proxy. window.MMPM_CONFIG is served separately
+    by ep_ui_config.py and loaded via a <script src> tag in index.html.
     """
 
     def __init__(self):
@@ -37,22 +36,13 @@ class Ui(Endpoint):
                 return send_from_directory(_ui_path, path)  # type: ignore
 
             env = MMPMEnv()
-            api_base = env.MMPM_UI_API_BASE_URL.get()
-            hostname = request.host.split(":")[0]
-            default_socket_url = f"http://{hostname}:{urls.MMPM_REPEATER_SERVER_PORT}"
-            socket_url = env.MMPM_UI_SOCKET_URL.get() or default_socket_url
             base_url = env.MMPM_UI_BASE_URL.get()
-
-            config_script = f'<script>window.MMPM_CONFIG={{"apiBase":"{api_base}","socketUrl":"{socket_url}","baseUrl":"{base_url}"}};</script>'
 
             with open(os.path.join(_ui_path, "index.html"), encoding="utf-8") as fh:
                 html = fh.read()
 
             if base_url:
                 base_href = urlparse(base_url).path.rstrip("/") + "/"
-                html = html.replace('<base href="/">', f'<base href="{base_href}">', 1)
+                html = re.sub(r'<base href="/"[^>]*>', f'<base href="{base_href}">', html, count=1)
 
-            return Response(
-                html.replace("</head>", f"{config_script}</head>", 1),
-                mimetype="text/html",
-            )
+            return Response(html, mimetype="text/html")

--- a/mmpm/api/endpoints/ep_ui.py
+++ b/mmpm/api/endpoints/ep_ui.py
@@ -1,5 +1,6 @@
 import importlib.resources as pkg_resources
 import os
+from urllib.parse import urlparse
 
 from flask import Blueprint, Response, request, send_from_directory
 
@@ -17,8 +18,9 @@ class Ui(Endpoint):
     """
     Catch-all endpoint that serves the Angular SPA and injects runtime config
     (window.MMPM_CONFIG) into index.html so the pre-built bundle works behind
-    a reverse proxy without rebuilding. Configure MMPM_UI_API_BASE_URL and
-    MMPM_UI_SOCKET_URL in the MMPM env file (~/.config/mmpm/mmpm-env.json).
+    a reverse proxy without rebuilding. Configure MMPM_UI_API_BASE_URL,
+    MMPM_UI_SOCKET_URL, and MMPM_UI_BASE_URL in the MMPM env file
+    (~/.config/mmpm/mmpm-env.json).
     """
 
     def __init__(self):
@@ -39,11 +41,16 @@ class Ui(Endpoint):
             hostname = request.host.split(":")[0]
             default_socket_url = f"http://{hostname}:{urls.MMPM_REPEATER_SERVER_PORT}"
             socket_url = env.MMPM_UI_SOCKET_URL.get() or default_socket_url
+            base_url = env.MMPM_UI_BASE_URL.get()
 
-            config_script = f'<script>window.MMPM_CONFIG={{"apiBase":"{api_base}","socketUrl":"{socket_url}"}};</script>'
+            config_script = f'<script>window.MMPM_CONFIG={{"apiBase":"{api_base}","socketUrl":"{socket_url}","baseUrl":"{base_url}"}};</script>'
 
             with open(os.path.join(_ui_path, "index.html"), encoding="utf-8") as fh:
                 html = fh.read()
+
+            if base_url:
+                base_href = urlparse(base_url).path.rstrip("/") + "/"
+                html = html.replace('<base href="/">', f'<base href="{base_href}">', 1)
 
             return Response(
                 html.replace("</head>", f"{config_script}</head>", 1),

--- a/mmpm/api/endpoints/ep_ui_config.py
+++ b/mmpm/api/endpoints/ep_ui_config.py
@@ -30,7 +30,9 @@ class UiConfig(Endpoint):
                 "socketUrl": socket_url,
                 "baseUrl": env.MMPM_UI_BASE_URL.get(),
             }
-            return Response(
+            response = Response(
                 f"window.MMPM_CONFIG={json.dumps(config)};",
                 mimetype="application/javascript",
             )
+            response.headers["Cache-Control"] = "no-store"
+            return response

--- a/mmpm/api/endpoints/ep_ui_config.py
+++ b/mmpm/api/endpoints/ep_ui_config.py
@@ -1,12 +1,10 @@
 import json
 
-from flask import Blueprint, Response
+from flask import Blueprint, Response, request
 
 from mmpm.api.endpoints.endpoint import Endpoint
+from mmpm.constants import urls
 from mmpm.env import MMPMEnv
-from mmpm.log.factory import MMPMLogFactory
-
-logger = MMPMLogFactory.get_logger(__name__)
 
 
 class UiConfig(Endpoint):
@@ -24,9 +22,12 @@ class UiConfig(Endpoint):
         @self.blueprint.route("/api/ui-config", methods=["GET"])
         def ui_config() -> Response:
             env = MMPMEnv()
+            hostname = request.host.split(":")[0]
+            default_socket_url = f"http://{hostname}:{urls.MMPM_REPEATER_SERVER_PORT}"
+            socket_url = env.MMPM_UI_SOCKET_URL.get() or default_socket_url
             config = {
                 "apiBase": env.MMPM_UI_API_BASE_URL.get(),
-                "socketUrl": env.MMPM_UI_SOCKET_URL.get(),
+                "socketUrl": socket_url,
                 "baseUrl": env.MMPM_UI_BASE_URL.get(),
             }
             return Response(

--- a/mmpm/api/endpoints/ep_ui_config.py
+++ b/mmpm/api/endpoints/ep_ui_config.py
@@ -1,0 +1,35 @@
+import json
+
+from flask import Blueprint, Response
+
+from mmpm.api.endpoints.endpoint import Endpoint
+from mmpm.env import MMPMEnv
+from mmpm.log.factory import MMPMLogFactory
+
+logger = MMPMLogFactory.get_logger(__name__)
+
+
+class UiConfig(Endpoint):
+    """
+    Serves window.MMPM_CONFIG as a JavaScript snippet so static file servers
+    can serve index.html without needing HTML injection. index.html loads this
+    via <script src="api/ui-config">.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.name = "ui_config"
+        self.blueprint = Blueprint(self.name, __name__)
+
+        @self.blueprint.route("/api/ui-config", methods=["GET"])
+        def ui_config() -> Response:
+            env = MMPMEnv()
+            config = {
+                "apiBase": env.MMPM_UI_API_BASE_URL.get(),
+                "socketUrl": env.MMPM_UI_SOCKET_URL.get(),
+                "baseUrl": env.MMPM_UI_BASE_URL.get(),
+            }
+            return Response(
+                f"window.MMPM_CONFIG={json.dumps(config)};",
+                mimetype="application/javascript",
+            )

--- a/mmpm/env.py
+++ b/mmpm/env.py
@@ -18,6 +18,7 @@ MMPM_DEFAULT_ENV: dict = {
     "MMPM_LOG_LEVEL": "INFO",
     "MMPM_UI_API_BASE_URL": "",
     "MMPM_UI_SOCKET_URL": "",
+    "MMPM_UI_BASE_URL": "",
 }
 
 MMPM_ENV_DESCRIPTIONS: dict = {
@@ -29,6 +30,7 @@ MMPM_ENV_DESCRIPTIONS: dict = {
     "MMPM_LOG_LEVEL": "Logging verbosity for MMPM. Accepted values: DEBUG, INFO, WARNING, ERROR, CRITICAL.",
     "MMPM_UI_API_BASE_URL": "Override the base URL the web UI uses to reach the MMPM REST API. Set this when the UI is served behind a reverse proxy at a custom path.",
     "MMPM_UI_SOCKET_URL": "Override the WebSocket URL the web UI uses to connect to the MMPM API. Required when a reverse proxy handles WebSocket connections on a non-default path.",
+    "MMPM_UI_BASE_URL": "Override the base URL the web UI is served from. Set this when the UI is hosted behind a reverse proxy at a custom sub-path (e.g. http://host/mmpm). The path component is injected as <base href> in index.html so assets and routing resolve correctly.",
 }
 
 
@@ -128,6 +130,7 @@ class MMPMEnv(Singleton):
         self.MMPM_LOG_LEVEL: EnvVar = None
         self.MMPM_UI_API_BASE_URL: EnvVar = None
         self.MMPM_UI_SOCKET_URL: EnvVar = None
+        self.MMPM_UI_BASE_URL: EnvVar = None
 
         env_vars = {}
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -20,13 +20,15 @@ class MockedMMPMEnv(MMPMEnv):
     def __init__(self):
         super().__init__()
 
-        # Mock the environment variables here
         self.MMPM_MAGICMIRROR_ROOT = MutableMagicMock()
         self.MMPM_MAGICMIRROR_URI = MutableMagicMock()
         self.MMPM_MAGICMIRROR_PM2_PROCESS_NAME = MutableMagicMock()
         self.MMPM_MAGICMIRROR_DOCKER_COMPOSE_FILE = MutableMagicMock()
         self.MMPM_IS_DOCKER_IMAGE = MutableMagicMock()
         self.mmpm_log_level = MutableMagicMock()
+        self.MMPM_UI_API_BASE_URL = MutableMagicMock()
+        self.MMPM_UI_SOCKET_URL = MutableMagicMock()
+        self.MMPM_UI_BASE_URL = MutableMagicMock()
 
         self.MMPM_MAGICMIRROR_ROOT.get.return_value = Path("/tmp/MagicMirror")
         self.MMPM_MAGICMIRROR_URI.get.return_value = "http://localhost:8080"
@@ -34,3 +36,6 @@ class MockedMMPMEnv(MMPMEnv):
         self.MMPM_MAGICMIRROR_DOCKER_COMPOSE_FILE.get.return_value = ""
         self.MMPM_IS_DOCKER_IMAGE.get.return_value = False
         self.mmpm_log_level.get.return_value = "INFO"
+        self.MMPM_UI_API_BASE_URL.get.return_value = ""
+        self.MMPM_UI_SOCKET_URL.get.return_value = ""
+        self.MMPM_UI_BASE_URL.get.return_value = ""

--- a/tests/test_ep_ui.py
+++ b/tests/test_ep_ui.py
@@ -1,0 +1,64 @@
+import pytest
+from flask import Flask
+from unittest.mock import MagicMock, mock_open, patch
+
+from mmpm.api.endpoints.ep_ui import Ui
+
+FAKE_INDEX = '<html><head><base href="/" /></head><body><app-root></app-root></body></html>'
+
+
+@pytest.fixture
+def client():
+    app = Flask(__name__)
+    endpoint = Ui()
+    app.register_blueprint(endpoint.blueprint)
+    app.config["TESTING"] = True
+    return app.test_client()
+
+
+def _mock_env(base_url=""):
+    m = MagicMock()
+    m.MMPM_UI_BASE_URL.get.return_value = base_url
+    return m
+
+
+def test_serves_html_content_type(client):
+    with patch("mmpm.api.endpoints.ep_ui.MMPMEnv", return_value=_mock_env()), \
+         patch("builtins.open", mock_open(read_data=FAKE_INDEX)):
+        response = client.get("/")
+    assert "text/html" in response.content_type
+
+
+def test_base_href_replaced_when_base_url_set(client):
+    with patch("mmpm.api.endpoints.ep_ui.MMPMEnv", return_value=_mock_env("http://host/mmpm")), \
+         patch("builtins.open", mock_open(read_data=FAKE_INDEX)):
+        response = client.get("/")
+    assert b'<base href="/mmpm/">' in response.data
+
+
+def test_base_href_unchanged_when_base_url_empty(client):
+    with patch("mmpm.api.endpoints.ep_ui.MMPMEnv", return_value=_mock_env()), \
+         patch("builtins.open", mock_open(read_data=FAKE_INDEX)):
+        response = client.get("/")
+    assert b'<base href="/" />' in response.data
+
+
+def test_mmpm_config_not_injected(client):
+    with patch("mmpm.api.endpoints.ep_ui.MMPMEnv", return_value=_mock_env()), \
+         patch("builtins.open", mock_open(read_data=FAKE_INDEX)):
+        response = client.get("/")
+    assert b"MMPM_CONFIG" not in response.data
+
+
+def test_base_href_extracted_from_full_url(client):
+    with patch("mmpm.api.endpoints.ep_ui.MMPMEnv", return_value=_mock_env("http://192.168.1.100/mmpm")), \
+         patch("builtins.open", mock_open(read_data=FAKE_INDEX)):
+        response = client.get("/")
+    assert b'<base href="/mmpm/">' in response.data
+
+
+def test_trailing_slash_normalised(client):
+    with patch("mmpm.api.endpoints.ep_ui.MMPMEnv", return_value=_mock_env("http://host/mmpm/")), \
+         patch("builtins.open", mock_open(read_data=FAKE_INDEX)):
+        response = client.get("/")
+    assert b'<base href="/mmpm/">' in response.data

--- a/tests/test_ep_ui_config.py
+++ b/tests/test_ep_ui_config.py
@@ -62,5 +62,13 @@ def test_empty_env_values(client):
     raw = response.data.decode()
     config = json.loads(raw.removeprefix("window.MMPM_CONFIG=").removesuffix(";"))
     assert config["apiBase"] == ""
-    assert config["socketUrl"] == ""
+    assert config["socketUrl"] == "http://localhost:8907"
     assert config["baseUrl"] == ""
+
+
+def test_socket_url_defaults_when_empty(client):
+    with patch("mmpm.api.endpoints.ep_ui_config.MMPMEnv", return_value=_mock_env(socket_url="")):
+        response = client.get("/api/ui-config")
+    raw = response.data.decode()
+    config = json.loads(raw.removeprefix("window.MMPM_CONFIG=").removesuffix(";"))
+    assert config["socketUrl"] == "http://localhost:8907"

--- a/tests/test_ep_ui_config.py
+++ b/tests/test_ep_ui_config.py
@@ -1,0 +1,66 @@
+import json
+import pytest
+from flask import Flask
+from unittest.mock import MagicMock, patch
+
+from mmpm.api.endpoints.ep_ui_config import UiConfig
+
+
+@pytest.fixture
+def client():
+    app = Flask(__name__)
+    endpoint = UiConfig()
+    app.register_blueprint(endpoint.blueprint)
+    app.config["TESTING"] = True
+    return app.test_client()
+
+
+def _mock_env(api_base="", socket_url="", base_url=""):
+    m = MagicMock()
+    m.MMPM_UI_API_BASE_URL.get.return_value = api_base
+    m.MMPM_UI_SOCKET_URL.get.return_value = socket_url
+    m.MMPM_UI_BASE_URL.get.return_value = base_url
+    return m
+
+
+def test_returns_200(client):
+    with patch("mmpm.api.endpoints.ep_ui_config.MMPMEnv", return_value=_mock_env()):
+        response = client.get("/api/ui-config")
+    assert response.status_code == 200
+
+
+def test_content_type_is_javascript(client):
+    with patch("mmpm.api.endpoints.ep_ui_config.MMPMEnv", return_value=_mock_env()):
+        response = client.get("/api/ui-config")
+    assert "javascript" in response.content_type
+
+
+def test_response_assigns_mmpm_config(client):
+    with patch("mmpm.api.endpoints.ep_ui_config.MMPMEnv", return_value=_mock_env()):
+        response = client.get("/api/ui-config")
+    assert response.data.decode().startswith("window.MMPM_CONFIG=")
+
+
+def test_config_values_from_env(client):
+    env = _mock_env(
+        api_base="http://host/mmpm",
+        socket_url="http://host/mmpm/repeater",
+        base_url="http://host/mmpm",
+    )
+    with patch("mmpm.api.endpoints.ep_ui_config.MMPMEnv", return_value=env):
+        response = client.get("/api/ui-config")
+    raw = response.data.decode()
+    config = json.loads(raw.removeprefix("window.MMPM_CONFIG=").removesuffix(";"))
+    assert config["apiBase"] == "http://host/mmpm"
+    assert config["socketUrl"] == "http://host/mmpm/repeater"
+    assert config["baseUrl"] == "http://host/mmpm"
+
+
+def test_empty_env_values(client):
+    with patch("mmpm.api.endpoints.ep_ui_config.MMPMEnv", return_value=_mock_env()):
+        response = client.get("/api/ui-config")
+    raw = response.data.decode()
+    config = json.loads(raw.removeprefix("window.MMPM_CONFIG=").removesuffix(";"))
+    assert config["apiBase"] == ""
+    assert config["socketUrl"] == ""
+    assert config["baseUrl"] == ""

--- a/ui/src/index.html
+++ b/ui/src/index.html
@@ -40,6 +40,8 @@
       to   { opacity: 1; transform: translateY(0); }
     }
   </style>
+
+  <script src="api/ui-config"></script>
 </head>
 
 <body>


### PR DESCRIPTION
Injects the path component as <base href> in index.html at serve time so Angular assets and routing resolve correctly when the UI is hosted at a custom sub-path (e.g. /mmpm) without requiring a rebuild.